### PR TITLE
Remove pliny dev dependency

### DIFF
--- a/greencache.gemspec
+++ b/greencache.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "fakeredis", "~> 0.5"
-  spec.add_development_dependency "pliny", "~> 0.0"
+  spec.add_development_dependency "multi_json", "~> 1.9",  ">= 1.9.3"
 
   spec.add_dependency "fernet", "~> 2.1"
   spec.add_dependency "redis", "~> 3.1"

--- a/spec/greencache_spec.rb
+++ b/spec/greencache_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 require 'fernet'
+require 'logger'
+require 'multi_json'
 
 Greencache.configure do |c|
   c.redis = Redis.new
-  c.logger = Pliny
+  c.logger = Logger.new(StringIO.new)
   c.silent = true
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,6 @@ Bundler.require
 require 'greencache'
 require 'redis'
 require 'fakeredis'
-require 'pliny'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
The only thing pliny is used for is the specs logger, and loading of multi_json.
