### PR TITLE
Add minicache for faster re-lookups within the same request

### DIFF
--- a/greencache.gemspec
+++ b/greencache.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fernet", "~> 2.1"
   spec.add_dependency "redis", "~> 3.1"
   spec.add_dependency "multi_json", "~> 1.9", ">= 1.9.3"
+  spec.add_dependency "mini_cache", "~> 1.1.0"
 end

--- a/lib/greencache/version.rb
+++ b/lib/greencache/version.rb
@@ -1,3 +1,3 @@
 module Greencache
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/greencache_spec.rb
+++ b/spec/greencache_spec.rb
@@ -100,6 +100,19 @@ describe Greencache do
     rc.get_value("foo", {encrypt: true})
   end
 
+  it "gets a value from memory if a rapid re-lookup" do
+    expect(rc.redis).not_to receive(:get).with("foo")
+    rc.cache ("foo") { "bar" }
+    rc.cache ("foo") { "bar" }
+  end
+
+  it "gets a value from redis if a slow re-lookup" do
+    expect(rc.redis).to receive(:get).with("foo").once
+    rc.cache ("foo") { "bar" }
+    sleep(1)
+    rc.cache ("foo") { "bar" }
+  end
+
   it 'can set a value' do
     expect(rc.redis).to receive(:setex).with("foo", 100, '"bar"')
     rc.set_value("foo", "bar", {cache_time: 100, encrypt: false})


### PR DESCRIPTION
Any lookups for the same key within a second are using in-memory cache rather than reaching out over the network to redis